### PR TITLE
Feature update frameworks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,40 +15,28 @@ jobs:
       matrix:
         options:
           - os: ubuntu-latest
-            framework: net5.0
+            framework: net8.0
             runtime: -x64
             codecov: false
           - os: macos-latest
-            framework: net5.0
+            framework: net8.0
             runtime: -x64
             codecov: false
           - os: windows-latest
-            framework: net5.0
+            framework: net8.0
             runtime: -x64
             codecov: false
           - os: ubuntu-latest
-            framework: netcoreapp3.1
+            framework: net9.0
             runtime: -x64
-            codecov: true
+            codecov: false
           - os: macos-latest
-            framework: netcoreapp3.1
+            framework: net9.0
             runtime: -x64
             codecov: false
           - os: windows-latest
-            framework: netcoreapp3.1
+            framework: net9.0
             runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: netcoreapp2.1
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: net472
-            runtime: -x64
-            codecov: false
-          - os: windows-latest
-            framework: net472
-            runtime: -x86
             codecov: false
 
     runs-on: ${{matrix.options.os}}
@@ -94,9 +82,8 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            5.0.x
-            3.1.x
-            2.1.x
+            8.0.x
+            9.0.x
 
       - name: Build
         shell: pwsh
@@ -142,9 +129,9 @@ jobs:
         shell: pwsh
         run: ./ci-pack.ps1
 
-      - name: Publish to MyGet
-        shell: pwsh
-        run: |
-          nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
-          nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
-        # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org
+      #- name: Publish to MyGet
+      #  shell: pwsh
+      #  run: |
+      #    nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
+      #    nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json
+      #  # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ bld/
 # Visual Studo 2015 cache/options directory
 .vs/
 
+# Visual Studio Code
+.vscode/
+
 # Jetbrains Rider cache/options directory
 .idea/
 

--- a/ZlibStream.sln
+++ b/ZlibStream.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ZlibStream", "src\ZlibStream\ZlibStream.csproj", "{0C89B7A2-A218-49E4-B545-5B044A45F977}"
 EndProject

--- a/src/ZlibStream/ZlibStream.csproj
+++ b/src/ZlibStream/ZlibStream.csproj
@@ -4,37 +4,16 @@
     <AssemblyName>SixLabors.ZlibStream</AssemblyName>
     <AssemblyTitle>SixLabors.ZlibStream</AssemblyTitle>
     <RootNamespace>SixLabors.ZlibStream</RootNamespace>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackageId>SixLabors.ZlibStream</PackageId>
     <PackageIcon>sixlabors.128.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/SixLabors/ZlibStream/</RepositoryUrl>
+    <RepositoryUrl Condition="'$(RepositoryUrl)' == ''">https://github.com/hjred/ZlibStream/</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <Description>A cross platform, managed, implementation of Zlib.</Description>
     <NeutralLanguage>en</NeutralLanguage>
     <MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
   </PropertyGroup>
-
-  <Choose>
-    <When Condition="'$(SIXLABORS_TESTING)' == 'true'">
-      <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;netstandard1.3;net472</TargetFrameworks>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) OR '$(TargetFramework)' == 'net472'">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\shared-infrastructure\branding\icons\org\sixlabors.128.png" Pack="true" PackagePath="" />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <!-- Test Dependencies -->
-    <PackageReference Update="SharpZipLib" Version="1.3.1" />
+    <PackageReference Update="SharpZipLib" Version="1.4.2" />
     <PackageReference Update="zlib.managed" Version="1.1.5-preview-99682104" />
   </ItemGroup>
 

--- a/tests/ZlibStream.Benchmarks/Config.cs
+++ b/tests/ZlibStream.Benchmarks/Config.cs
@@ -48,7 +48,7 @@ namespace ZlibStream.Benchmarks
     public class ShortRun : Config
     {
         public ShortRun()
-            => this.AddJob(Job.Default.WithRuntime(CoreRuntime.Core31).WithLaunchCount(1).WithWarmupCount(3).WithIterationCount(3));
+            => this.AddJob(Job.Default.WithRuntime(CoreRuntime.Core80).WithLaunchCount(1).WithWarmupCount(3).WithIterationCount(3));
     }
 
     public class ByteSizeColumn : IColumn

--- a/tests/ZlibStream.Benchmarks/ZlibStream.Benchmarks.csproj
+++ b/tests/ZlibStream.Benchmarks/ZlibStream.Benchmarks.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>ZlibStream.Benchmarks</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <!--Used to hide test project from dotnet test-->
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" Condition="'$(IsWindows)'=='true'" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.2" Condition="'$(IsWindows)'=='true'" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="zlib.managed" />
   </ItemGroup>

--- a/tests/ZlibStream.Tests/ZlibStream.Tests.csproj
+++ b/tests/ZlibStream.Tests/ZlibStream.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugSymbols>True</DebugSymbols>
     <IsTestProject>True</IsTestProject>


### PR DESCRIPTION
- update net versions to 8.0 and 9.0 only
- removed net framework targetting
- updated solution file to VS 2022
- disable code coverage and publishing to MyGet for now
- updated vulnerable SharpZipLib dependency
- updated BenchmarkDotNet dependency to support net8.0 and net9.0